### PR TITLE
Flexibel gl and glm includes

### DIFF
--- a/include/glowl/BufferObject.hpp
+++ b/include/glowl/BufferObject.hpp
@@ -8,8 +8,6 @@
 #ifndef GLOWL_BUFFEROBJECT_HPP
 #define GLOWL_BUFFEROBJECT_HPP
 
-#include <glad/glad.h>
-
 #include <iostream>
 
 namespace glowl

--- a/include/glowl/GLSLProgram.hpp
+++ b/include/glowl/GLSLProgram.hpp
@@ -14,7 +14,6 @@
 #include <utility>
 #include <vector>
 
-#include <glad/glad.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>

--- a/include/glowl/GLSLProgram.hpp
+++ b/include/glowl/GLSLProgram.hpp
@@ -14,10 +14,13 @@
 #include <utility>
 #include <vector>
 
+#if __has_include(<glm/glm.hpp>)
 #include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
-#include <glm/vec3.hpp>
+#define GLOWL_USE_GLM 1
+#else
+#define GLOWL_USE_GLM 0
+#endif
 
 #include "Exceptions.hpp"
 
@@ -96,6 +99,7 @@ namespace glowl
         void setUniform(GLchar const* name, GLuint v0, GLuint v1);
         void setUniform(GLchar const* name, GLuint v0, GLuint v1, GLuint v2);
         void setUniform(GLchar const* name, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
+#if GLOWL_USE_GLM
         void setUniform(GLchar const* name, glm::vec2 const& v);
         void setUniform(GLchar const* name, glm::vec3 const& v);
         void setUniform(GLchar const* name, glm::vec4 const& v);
@@ -105,6 +109,7 @@ namespace glowl
         void setUniform(GLchar const* name, glm::mat2 const& m);
         void setUniform(GLchar const* name, glm::mat3 const& m);
         void setUniform(GLchar const* name, glm::mat4 const& m);
+#endif
 
         /**
          * \brief Return the position of a uniform.
@@ -319,6 +324,7 @@ namespace glowl
         glUniform4ui(getUniformLocation(name), v0, v1, v2, v3);
     }
 
+#if GLOWL_USE_GLM
     inline void GLSLProgram::setUniform(GLchar const* name, glm::vec2 const& v)
     {
         glUniform2fv(getUniformLocation(name), 1, glm::value_ptr(v));
@@ -363,6 +369,7 @@ namespace glowl
     {
         glUniformMatrix4fv(getUniformLocation(name), 1, GL_FALSE, glm::value_ptr(m));
     }
+#endif
 
     inline GLuint GLSLProgram::getUniformLocation(GLchar const* name)
     {

--- a/include/glowl/Mesh.hpp
+++ b/include/glowl/Mesh.hpp
@@ -8,9 +8,6 @@
 #ifndef GLOWL_MESH_HPP
 #define GLOWL_MESH_HPP
 
-// Include glad for OpenGL types and functions
-#include <glad/glad.h>
-
 // Include std libs
 #include <string>
 #include <vector>

--- a/include/glowl/Texture.hpp
+++ b/include/glowl/Texture.hpp
@@ -8,8 +8,6 @@
 #ifndef GLOWL_TEXTURE_HPP
 #define GLOWL_TEXTURE_HPP
 
-#include <glad/glad.h>
-
 #include <string>
 #include <vector>
 

--- a/include/glowl/VertexLayout.hpp
+++ b/include/glowl/VertexLayout.hpp
@@ -8,8 +8,6 @@
 #ifndef GLOWL_VERTEXLAYOUT_HPP
 #define GLOWL_VERTEXLAYOUT_HPP
 
-#include <glad/glad.h>
-
 namespace glowl
 {
 


### PR DESCRIPTION
- Remove glad include to become independent of gl loader. User must include gl headers before glowl now.
- Include glm only if available.

Fix #10, #11.